### PR TITLE
Only list dependencies needed for library

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,18 +13,19 @@
   "author": "ft",
   "license": "ISC",
   "dependencies": {
-    "jade": "^1.11.0",
-    "jade-gist": "^1.0.3",
     "marked": "^0.3.2",
     "min-qs": "^1.3.0",
-    "min-util": "^2.3.0",
-    "raw-loader": "^0.5.1",
-    "webpack": "^1.14.0"
+    "min-util": "^2.3.0"
   },
   "bin": {
     "markdown2confluence": "bin/markdown2confluence.js"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "jade": "^1.11.0",
+    "jade-gist": "^1.0.3",
+    "raw-loader": "^0.5.1",
+    "webpack": "^1.14.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/chunpu/markdown2confluence.git"


### PR DESCRIPTION
There's only a few ways this library is used, and this change should not
impact any of them.

1. Library for another tool: the devDependencies are not used.
2. Command-line client: the devDependencies are not used.
3. Local development: the devDependencies would be installed.
4. Automated tests: the devDependencies are installed.
5. Automated documentation: the devDependencies are installed.

Pulling in this change will significantly reduce the number of
dependencies when other people use markdown2confluence in their
software.

After:

```
├── marked@0.3.6
├─┬ min-qs@1.3.0
│ └── min-util@2.3.0
└─┬ min-util@2.3.0
  └─┬ cou@1.3.0
    └── min-is@2.2.0
```

Before:

```
├─┬ jade@1.11.0
│ ├── character-parser@1.2.1
│ ├─┬ clean-css@3.4.25
│ │ ├── commander@2.8.1
│ │ └── source-map@0.4.4
│ ├── commander@2.6.0
│ ├─┬ constantinople@3.0.2
│ │ └── acorn@2.7.0
│ ├─┬ jstransformer@0.0.2
│ │ ├── is-promise@2.1.0
│ │ └─┬ promise@6.1.0
│ │   └── asap@1.0.0
│ ├─┬ transformers@2.1.0
│ │ ├─┬ css@1.0.8
│ │ │ ├── css-parse@1.0.4
│ │ │ └── css-stringify@1.0.5
│ │ ├─┬ promise@2.0.0
│ │ │ └── is-promise@1.0.1
│ │ └─┬ uglify-js@2.2.5
│ │   ├── optimist@0.3.7
│ │   └── source-map@0.1.43
│ ├── void-elements@2.0.1
│ └─┬ with@4.0.3
│   ├── acorn@1.2.2
│   └── acorn-globals@1.0.9
├── jade-gist@1.0.5
├─┬ min-util@1.10.1
│ └─┬ cou@1.3.0
│   └── min-is@2.2.0
├── raw-loader@0.5.1
└─┬ webpack@1.14.0
  ├── acorn@3.3.0
  ├── async@1.5.2
  ├── clone@1.0.2
  ├─┬ enhanced-resolve@0.9.1
  │ └── memory-fs@0.2.0
  ├── interpret@0.6.6
  ├─┬ loader-utils@0.2.17
  │ ├── big.js@3.1.3
  │ └── emojis-list@2.1.0
  ├── memory-fs@0.3.0
  ├─┬ node-libs-browser@0.7.0
  │ ├── assert@1.4.1
  │ ├─┬ browserify-zlib@0.1.4
  │ │ └── pako@0.2.9
  │ ├─┬ buffer@4.9.1
  │ │ ├── base64-js@1.2.0
  │ │ └── ieee754@1.1.8
  │ ├─┬ console-browserify@1.1.0
  │ │ └── date-now@0.1.4
  │ ├── constants-browserify@1.0.0
  │ ├─┬ crypto-browserify@3.3.0
  │ │ ├── browserify-aes@0.4.0
  │ │ ├── pbkdf2-compat@2.0.1
  │ │ ├── ripemd160@0.2.0
  │ │ └── sha.js@2.2.6
  │ ├── domain-browser@1.1.7
  │ ├── events@1.1.1
  │ ├── https-browserify@0.0.1
  │ ├── os-browserify@0.2.1
  │ ├── path-browserify@0.0.0
  │ ├── process@0.11.9
  │ ├── querystring-es3@0.2.1
  │ ├── stream-browserify@2.0.1
  │ ├─┬ stream-http@2.6.3
  │ │ ├── builtin-status-codes@3.0.0
  │ │ └── to-arraybuffer@1.0.1
  │ ├─┬ timers-browserify@2.0.2
  │ │ └── setimmediate@1.0.5
  │ ├── tty-browserify@0.0.0
  │ ├─┬ url@0.11.0
  │ │ ├── punycode@1.3.2
  │ │ └── querystring@0.2.0
  │ ├─┬ util@0.10.3
  │ │ └── inherits@2.0.1
  │ └─┬ vm-browserify@0.0.4
  │   └── indexof@0.0.1
  ├─┬ supports-color@3.2.3
  │ └── has-flag@1.0.0
  ├── tapable@0.1.10
  ├─┬ watchpack@0.2.9
  │ ├── async@0.9.2
  │ └─┬ chokidar@1.6.1
  │   ├─┬ anymatch@1.3.0
  │   │ └─┬ micromatch@2.3.11
  │   │   ├─┬ arr-diff@2.0.0
  │   │   │ └── arr-flatten@1.0.1
  │   │   ├── array-unique@0.2.1
  │   │   ├─┬ braces@1.8.5
  │   │   │ ├─┬ expand-range@1.8.2
  │   │   │ │ └─┬ fill-range@2.2.3
  │   │   │ │   ├── is-number@2.1.0
  │   │   │ │   ├── isobject@2.1.0
  │   │   │ │   └── randomatic@1.1.6
  │   │   │ ├── preserve@0.2.0
  │   │   │ └── repeat-element@1.1.2
  │   │   ├─┬ expand-brackets@0.1.5
  │   │   │ └── is-posix-bracket@0.1.1
  │   │   ├─┬ extglob@0.3.2
  │   │   │ └── is-extglob@1.0.0
  │   │   ├── filename-regex@2.0.0
  │   │   ├── is-extglob@1.0.0
  │   │   ├── is-glob@2.0.1
  │   │   ├── normalize-path@2.0.1
  │   │   ├─┬ object.omit@2.0.1
  │   │   │ └─┬ for-own@0.1.5
  │   │   │   └── for-in@1.0.2
  │   │   ├─┬ parse-glob@3.0.4
  │   │   │ ├─┬ glob-base@0.3.0
  │   │   │ │ ├── glob-parent@2.0.0
  │   │   │ │ └─┬ is-glob@2.0.1
  │   │   │ │   └── is-extglob@1.0.0
  │   │   │ ├── is-dotfile@1.0.2
  │   │   │ ├── is-extglob@1.0.0
  │   │   │ └── is-glob@2.0.1
  │   │   └─┬ regex-cache@0.4.3
  │   │     ├── is-equal-shallow@0.1.3
  │   │     └── is-primitive@2.0.0
  │   ├── async-each@1.0.1
  │   ├── glob-parent@2.0.0
  │   ├─┬ is-binary-path@1.0.1
  │   │ └── binary-extensions@1.8.0
  │   ├─┬ is-glob@2.0.1
  │   │ └── is-extglob@1.0.0
  │   └─┬ readdirp@2.1.0
  │     └── set-immediate-shim@1.0.1
  └─┬ webpack-core@0.6.9
    ├── source-list-map@0.1.8
    └── source-map@0.4.4
```