### PR TITLE
Allow text links to show up as linked text

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ _.extend(Renderer.prototype, rawRenderer.prototype, {
 	}
 	, link: function(href, title, text) {
 		var arr = [href]
-		if (title) {
-			arr.unshift(title)
+		if (title || text) {
+			arr.unshift(title || text)
 		}
 		return '[' + arr.join('|') + ']'
 	}


### PR DESCRIPTION
This allows the markdown `[desc](http://example.com)` to be rendered in Confluence as `[desc|http://example.com]`.