### PR TITLE
Add html and xml support and add case insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,11 @@ function Renderer() {}
 
 var rawRenderer = marked.Renderer
 
-var langArr = 'actionscript3 bash csharp coldfusion cpp css delphi diff erlang groovy java javafx javascript perl php none powershell python ruby scala sql vb html/xml html xml'.split(/\s+/)
+var langArr = 'actionscript3 bash csharp coldfusion cpp css delphi diff erlang groovy java javafx javascript perl php none powershell python ruby scala sql vb html/xml'.split(/\s+/)
 var langMap = {
-	shell: 'bash'
+	shell: 'bash', 
+	html: 'html', 
+	xml: 'xml', 
 }
 for (var i = 0, x; x = langArr[i++];) {
 	langMap[x] = x
@@ -89,8 +91,10 @@ _.extend(Renderer.prototype, rawRenderer.prototype, {
 	}
 	, code: function(code, lang) {
 		// {code:language=java|borderStyle=solid|theme=RDark|linenumbers=true|collapse=true}
-		lang = lang.toLowerCase()
-		lang = langMap[lang] || ''
+		if(lang) {
+			lang = lang.toLowerCase()
+		}
+		lang = langMap[lang] || 'none'
 		var param = {
 			language: lang,
 			borderStyle: 'solid',

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function Renderer() {}
 
 var rawRenderer = marked.Renderer
 
-var langArr = 'actionscript3 bash csharp coldfusion cpp css delphi diff erlang groovy java javafx javascript perl php none powershell python ruby scala sql vb html/xml'.split(/\s+/)
+var langArr = 'actionscript3 bash csharp coldfusion cpp css delphi diff erlang groovy java javafx javascript perl php none powershell python ruby scala sql vb html/xml html xml'.split(/\s+/)
 var langMap = {
 	shell: 'bash'
 }
@@ -89,6 +89,7 @@ _.extend(Renderer.prototype, rawRenderer.prototype, {
 	}
 	, code: function(code, lang) {
 		// {code:language=java|borderStyle=solid|theme=RDark|linenumbers=true|collapse=true}
+		lang = lang.toLowerCase()
 		lang = langMap[lang] || ''
 		var param = {
 			language: lang,

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var langArr = 'actionscript3 bash csharp coldfusion cpp css delphi diff erlang g
 var langMap = {
 	shell: 'bash', 
 	html: 'html', 
-	xml: 'xml', 
+	xml: 'xml'
 }
 for (var i = 0, x; x = langArr[i++];) {
 	langMap[x] = x


### PR DESCRIPTION
1、增加对xml和html格式的单独支持（原来只能写成html/xml）
2、语言不区分大小写（markdown的语言是不区分大小写的，java、Java、JAVA都可以识别，但原来只有全小写的java可以正确转化，其它情况都会导致markup中language=空）
3、目前code的语言不能识别时会置language=空，但在某些版本的Confluence中，language=空会导致报错，因此将默认置为language=none

注：只修改了index.js，未重新打包bundle.js
