### PR TITLE
Fix nested list items

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,10 +68,16 @@ _.extend(Renderer.prototype, rawRenderer.prototype, {
 			return line
 		})
 		var type = ordered ? '#' : '*'
-		return _.map(arr, function(line) {
-			return type + ' ' + line
+		return '\n' + _.map(arr, function(line) {
+			var bullet = type
+			if (!/^[*#]+ /.test(line)) {
+				// When the line starts with '# ' or '* ', it means that it is
+				// a nested list. '* * ' should be squashed to '** ' in the
+				// case.
+				bullet += ' '
+			}
+			return bullet + line;
 		}).join('\n') + '\n\n'
-
 	}
 	, listitem: function(body, ordered) {
 		return body + '\n'

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ var pairs = [
       ['# h1', 'h1. h1\n\n']
     , ['head1\n===', 'h1. head1\n\n']
     , ['###  h3', 'h3. h3\n\n']
+    , ['- item\n  - nested', '\n* item\n** nested\n\n']
 ]
 
 pairs.forEach(function(arr, i) {


### PR DESCRIPTION
### Problem

At first, create file as follows:

```markdown
- item
  - nested
```

And run `markdown2confluence`.

I expected

```
* item
** nested
```

but actually got

```
* item* nested
```

It looked broken.

## Solution

So I fixed the renderer code handling the nested list by looking the head of each line in list items. Now it returns expected output.